### PR TITLE
verify that the length of the blobRef is not less than 32

### DIFF
--- a/gopkg/da-rpc/near.go
+++ b/gopkg/da-rpc/near.go
@@ -57,7 +57,7 @@ func (f *BlobRef) MarshalBinary() ([]byte, error) {
 }
 
 func (f *BlobRef) UnmarshalBinary(ref []byte) error {
-	if len(ref) != sidecar.EncodedBlobRefSize {
+	if len(ref) < sidecar.EncodedBlobRefSize {
 		log.Warn("invalid size ", len(ref), " expected ", sidecar.EncodedBlobRefSize)
 		return ErrInvalidSize
 	}


### PR DESCRIPTION
The length of blobRef before v0.4.0 was 64 and now it is 32, which may cause "NEAR DA unmarshal blob: invalid size" error for client with v0.4.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Nuffle-Labs/data-availability/110)
<!-- Reviewable:end -->
