### PR TITLE
fix(plasma): alt-da requires only commitments to be encoded in hexadecimal

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+sdldslk

--- a/bin/sidecar/src/main.rs
+++ b/bin/sidecar/src/main.rs
@@ -153,8 +153,10 @@ async fn submit(
     Ok(blob_ref.into())
 }
 
-pub(crate) fn stream_response(chunk: Vec<u8>) -> Response {
-    let s = stream::iter(["0x".to_string(), hex::encode(chunk)]).map(|r| Ok::<_, anyhow::Error>(r));
+pub(crate) fn stream_response<T: Into<axum::body::Bytes> + Send + Sync + 'static>(
+    chunk: T,
+) -> Response {
+    let s = stream::iter([chunk]).map(|r| Ok::<_, anyhow::Error>(r));
     Response::builder()
         .header("Content-Type", "application/octet-stream")
         .body(boxed(StreamBody::new(s)))


### PR DESCRIPTION
Tested with copypaste of the batcher client. For Future reference: https://github.com/ethereum-optimism/specs/blob/8efc7a3fe800367bb8f407ab4fe284570a18ebc9/specs/experimental/alt-da.md?plain=1#L99-L129 Is the specification, unfortunately the batcher client expects a raw utf8 bytearray over the wire.
```
HTTP/1.1 200 OK
content-type: application/octet-stream
date: Wed, 10 Jul 2024 13:00:35 GMT
transfer-encoding: chunked

n[T����gL#3�Z�I'Co��JX�?�OT`�
```
Not a hex encoded commitment. Notably, they do encode it further downstream for the eth tx, so I wonder if they are doubling their  commitment sizes if people are encoding at source and they are reencoding before sending to eth. Or perhaps I was stupid enough to be the only person who blindly followed the spec. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Nuffle-Labs/data-availability/122)
<!-- Reviewable:end -->
