### PR TITLE
Temporarily disable da-rpc assembly in manual workflow

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -20,15 +20,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build "da-rpc" Docker image and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          file: ./crates/da-rpc-sys/Dockerfile
-          tags: |
-            ghcr.io/nuffle-labs/data-availability/da-rpc:${{ github.sha }}
-            ghcr.io/nuffle-labs/data-availability/da-rpc:latest
+      # - name: Build "da-rpc" Docker image and push
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     push: true
+      #     file: ./crates/da-rpc-sys/Dockerfile
+      #     tags: |
+      #       ghcr.io/nuffle-labs/data-availability/da-rpc:${{ github.sha }}
+      #       ghcr.io/nuffle-labs/data-availability/da-rpc:latest
 
       - name: Build "sidecar" Docker image and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Nuffle-Labs/data-availability/131)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Commented out the steps for building and pushing the "da-rpc" Docker image in the workflow.
	- Maintained existing functionality for building and pushing the "sidecar" Docker image and generating the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->